### PR TITLE
dashboard

### DIFF
--- a/lua/neodash/dashboard.lua
+++ b/lua/neodash/dashboard.lua
@@ -1,0 +1,73 @@
+-- /neodash.nvim/lua/neodash/dashboard.lua created by DBTow
+
+-- This code will be responsible for rendering the dashboard on startup
+
+local dashboard = {}
+
+local buf
+
+local art = {
+	"	⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣶⣄⡀⢀⣀⣠⣤⣤⣶⣶⣶⣤⣤⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀ ",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣠⣤⣿⠿⣩⣿⣿⣿⣿⣯⣛⣻⣯⣍⡛⣿⣿⣦⢰⣶⣄⡀⠀⠀⠀⠀⠀⠀⠀ ",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣽⣿⡟⢹⣫⡿⠛⣿⣿⣿⠿⣛⣿⣿⣿⣿⠙⣿⣿⣿⣯⠻⣿⣿⣷⣄⠀⠀⠀⠀⠀ ",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣼⣿⡿⡟⣰⣶⠈⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣆⢻⣿⣿⡿⣧⣈⠻⣿⣿⣷⡀⠀⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣿⣿⣿⢰⡇⢿⡟⢰⣿⣿⣿⣿⣿⣿⣿⠿⠿⣿⣿⣿⣿⣿⣿⣷⠈⢿⣧⡀⣿⣿⣿⡄⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣿⣿⣿⣿⠘⣷⢨⣿⠀⠻⢿⣿⣯⣤⣾⢃⣤⣶⣿⣿⣿⣿⣿⣿⣿⡏⠙⣿⣷⣿⣿⣿⣃⣤⡶⠀",
+	"⠀⠀⠀⠀⣠⣴⣶⣶⣶⣿⡿⢹⣿⣿⠀⣿⣌⠛⠀⣠⣤⣌⡛⠿⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⣠⡙⢿⣿⣿⣿⣿⠋⠀⠀",
+	"⠈⠓⠦⢾⠿⠛⠙⠛⠛⢉⣠⣾⣿⡟⠙⣦⡀⠀⡻⣿⣿⣿⣿⠒⠀⣿⠟⠁⣹⣉⠉⣿⣿⣿⣿⣿⣿⣷⠈⣿⣿⣿⡿⣾⠏⠀",
+	"⣀⡤⠤⠦⣴⣴⣶⣶⣶⣿⣿⣿⣿⡇⣰⣿⡟⠀⠳⣦⣄⣉⠛⠀⠀⢿⣿⣿⣿⡻⣶⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⢹⣤⡄",
+	"⠁⢀⣀⣠⣤⡽⠟⠿⣿⣿⣿⠿⢋⣴⣿⣿⣿⠀⠀⠻⣷⣉⠉⢛⢷⣦⣝⠿⠿⣯⣭⣸⣿⣿⣿⣇⠻⣿⣿⣿⡿⣋⠁⢸⡿⠁",
+	"⠀⠈⠙⣿⣥⣄⣀⣀⣀⣠⠤⠒⠋⢿⣿⠟⣩⠴⣶⠖⠈⠙⢷⣮⠳⣦⡍⢁⣾⣿⣿⣿⣿⣿⣿⣿⣿⣾⠿⢿⣃⡿⠃⣭⣧⣄",
+	"⠀⠀⠒⠉⢿⣿⣿⣿⣿⣿⣶⣤⣄⣈⣉⣹⣵⡾⠋⠻⠿⢶⡆⠉⣡⣈⠁⠀⢮⣉⠙⠻⣅⢸⣿⠿⠋⣠⣴⡿⢋⣵⡖⣿⡉⠉",
+	"⠐⠒⠲⢦⣌⠛⠛⢋⣠⣾⣿⣿⣿⣿⣿⠿⠋⢀⠀⢀⠀⠸⠦⠔⠉⢻⣠⠤⢤⠉⠙⣛⡟⠉⠐⣶⠐⢿⡿⠃⠾⣁⡴⣿⣿⠀",
+	"⠀⠀⠀⠀⣿⣷⣶⣿⣿⠏⢀⣴⣶⠖⠀⠀⠀⠈⢩⠛⠻⢷⣦⡀⠀⠈⠁⠀⢠⡧⠴⠿⠿⡆⢀⣨⡤⣀⣠⣿⣶⣿⡷⢹⣧⠀",
+	"⠀⠀⠀⠀⠙⠻⠿⠟⠋⠀⣾⣿⣧⡀⠀⠀⠀⠀⠈⠳⣤⣀⠈⠛⢷⣤⣀⡀⠉⠀⠀⠀⠀⠸⠋⠀⠀⢸⣿⣿⣿⡏⠀⢸⣿⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⢰⣿⣿⣿⣧⠀⠀⠀⠀⠀⠀⠀⠉⠛⠛⠉⠀⠉⠀⠀⠀⢀⣠⣤⠤⠤⠴⢶⣾⣿⣿⣿⡇⠀⣼⠏⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⣿⣿⣿⣿⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣴⢿⣁⣀⣀⠀⣠⣿⣿⣿⣿⡟⠃⣰⡏⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣼⠃⠀⠈⠉⢀⣴⣿⣿⣿⣿⣿⡇⢰⣿⡇⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⣿⡿⠀⠀⠀⠀⠀⠀⠀⢰⡀⠀⠀⠀⢰⡇⠀⠀⣠⣴⣿⣿⣿⣿⣿⣿⣿⣇⢸⣿⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣀⣀⣤⣶⣿⣷⣶⣦⣌⣧⠀⠀⢠⣿⣀⣠⣾⣿⣿⣿⡿⢋⡩⠟⣿⣿⣇⡿⠋⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⣿⣿⣿⣿⠟⠁⠀⠈⠙⠻⣿⣿⣷⣤⣾⣿⣿⣿⠛⢉⣼⣟⣵⠏⣠⣾⢿⣿⡟⠁⠀⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⣿⣿⣿⠀⠀⠈⣲⣶⣤⣤⡀⢀⡿⠉⢻⣿⡇⠀⣾⡿⢸⠏⣴⡿⠁⣼⣿⡇⠀⠀⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣦⠀⠀⢻⣿⡏⠀⣰⡿⠁⠀⣾⣿⣿⢰⣿⠇⢸⣾⡟⠁⣼⣿⣿⡇⠀⠀⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⢿⣿⣿⣦⣼⣿⣃⡴⠋⠀⠀⢰⡿⣿⣿⢸⡿⢀⣾⠟⢀⣾⣿⣿⣿⠇⠀⠀⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠛⠛⠋⠉⠀⠀⠀⢀⣞⡕⢻⣿⢸⣷⡞⠁⣤⡿⢿⣿⣿⡟⠀⠀⠀⠀⠀⠀",
+	"⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡼⠎⣠⣾⡿⢸⡟⢀⣾⠟⢀⣼⣿⠏⠀⠀⠀⠀⠀  ",
+}
+
+--function createbuffer() {
+--	buf = nvim_create_buf(false, true)
+--	vim.api.nvim_buf_set_lines(buf, 0, -1, false, art)
+--return buf
+
+-- function dashboard.draw() {}
+
+function dashboard.test_floating_window()
+	-- Create a new scratch buffer
+	buf = vim.api.nvim_create_buf(false, true)
+
+	-- Set the content of the buffer (the ASCII art)
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, art)
+
+	-- Get the dimensions of the current Neovim UI
+	local ui = vim.api.nvim_list_uis()[1]
+	local width = math.floor(ui.width * 0.8)
+	local height = #art
+
+	local row = math.floor((ui.height - height) / 2)
+	local col = math.floor((ui.width - width) / 2)
+
+	-- Create a floating window
+	local win = vim.api.nvim_open_win(buf, true, {
+		relative = "editor",
+		width = width,
+		height = height,
+		row = row,
+		col = col,
+		style = "minimal",
+		border = "rounded"
+	})
+end
+
+
+return dashboard


### PR DESCRIPTION
On Initial Setup:

-.gitignore
-README.md

neodash.nvim/plugin/
-neodash.lua
-simply requires the 'neodash/' directory
(This is important for runtime path reasons)

neodash.nvim/lua/neodash/
-init.lua

init.lua
-Features a print message to ensure its properly loaded in the rtp

-Creates an autocmd that upon "VimEnter" (when neovim is entered) calls a callback function()
-This function simply checks the amount of arguments using vim.fn.argc() and saves the output to a variable
-The output is then checked and if its == 0 a message is printed
(In the future this print statement will be replaced with a function to render the neodash dashboard)

Why is this important? We only want neodash to open a buffer if neovim is not entered into the terminal with an argument (argc() == 0). If neovim is entered into the terminal with an argument... typically a file to open... we don't want to open the neodash dashboard


After Initial Setup:

Created a dashboard.lua (/lua/neodash/dashboard.lua)

This will house logic for rendering the dashboard
-Added an ASCII art I like to a lua table and saved it to a local variable... this will be featured in my personal neodash config
(simply a placeholder for right now)

-Added a test function that creates a buffer and sets the buffer contents to the ASCII art and then creates a floating window with the buffer contents
(Wanted to ensure that I could successfully render the entirety of the art to the buffer/floatingwindow)

This was all successful so committing at this point. Next we will be working on improving the UI and having it run on startup.
